### PR TITLE
AppVeyor CI Workflow for NadaMq (and other packages with C dependencies)

### DIFF
--- a/.conda-recipe/bld.bat
+++ b/.conda-recipe/bld.bat
@@ -24,7 +24,14 @@ if errorlevel 1 exit 1
 
 REM Run build tests
 "%PYTHON%" -m paver build_ext --inplace
-nosetests -v nadamq\tests
+nosetests "%SRC_DIR%"\\nadamq\\tests -vv --with-xunit
+
+REM If a project directory specified, then copy results into the directory
+IF DEFINED PROJECT_DIRECTORY (
+  cp .\\nosetests.xml "%PROJECT_DIRECTORY%"\\nosetests.xml
+  dir "%PROJECT_DIRECTORY%"
+)
+
 if errorlevel 1 exit 1
 
 REM Copy Arduino library files to Conda Arduino library.

--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -30,8 +30,8 @@ requirements:
   run:
     - python
     - c-array-defs >=0.2.post3
-    - mingw-runtime # [win]
     - numpy
+    - mingw # [win]
 
 test:
   imports:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# nadamq
+
+[![Build status](https://ci.appveyor.com/api/projects/status/8alcf70aa3f33s2q/branch/master?svg=true)](https://ci.appveyor.com/project/Lucaszw/nadamq/branch/master)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,72 @@
+environment:
+  GIT_REPOSITORY: http://github.com/wheeler-microfluidics/nadamq
+  PROJECT_NAME: nadamq
+  matrix:
+    - PYTHON_VERSION: 2.7
+      MINICONDA: C:\Miniconda
+      PYTHON_ARCH: "32"
+
+version: '1.0.{build}'
+
+init:
+  - "ECHO %PYTHON_VERSION% %MINICONDA%"
+
+install:
+  # Add Conda to path
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+
+  # Configure Conda to operate without user input
+  - conda config --set always_yes yes --set changeps1 no
+
+  # Add the conda-force, and wheeler-microfluidics channels
+  - conda config --add channels conda-forge
+  - conda config --add channels wheeler-microfluidics
+
+  # Update conda, and install conda-build (used for building in non-root env)
+  - conda update -q conda
+  - conda install --yes conda-build anaconda-client
+
+  # Create and activate new NadaMq environment
+  - conda create --name %PROJECT_NAME%
+  - "call %MINICONDA%\\Scripts\\activate.bat %PROJECT_NAME%"
+  - conda info -a
+
+  # Get output package location
+  - FOR /F "tokens=*" %%a in ('conda-build . --output') do SET PACKAGE_LOCATION=%%a
+  - echo %PACKAGE_LOCATION%
+
+  # Set environment variable for project location (may be used in bld.bat)
+  - set "PROJECT_DIRECTORY=%cd%"
+
+  # Build package
+  - conda-build .
+
+# Handle build and tests using conda (defined in .conda-recipe/meta.yaml)
+build: false
+test_script:
+  - echo Build Complete
+
+after_test:
+  # Add repository information to info.json file (unpackage tarfile to access index.json)
+  - ps: $package_name = (( $env:PACKAGE_LOCATION -split '\\') | Select-Object -Last 1) -split '\.bz2' | Select-Object -First 1
+  - ps: 7z e $env:PACKAGE_LOCATION -tbzip2
+  - ps: 7z x $package_name -opackage -ttar
+  - ps: $json = Get-Content '.\\package\\info\\index.json' | Out-String | ConvertFrom-Json
+
+  # Add members to info.json:
+  - ps: $json | Add-Member git_repository '$env:GIT_REPOSITORY'
+
+  # repackage tarfile
+  - ps: $json | ConvertTo-JSON | % { [System.Text.RegularExpressions.Regex]::Unescape($_) } | Set-Content .\package\info\index.json
+  - 7z a %PROJECT_NAME%.tar .\package\* -ttar
+  - 7z a %PROJECT_NAME%.tar.bz2 %PROJECT_NAME%.tar -tbzip2
+
+  # Save tarfile as artifact
+  - appveyor PushArtifact %PROJECT_NAME%.tar.bz2
+
+  # Upload to Anaconda Cloud
+  # - binstar -t %BINSTAR_TOKEN% upload --force package2.tar.bz2
+
+  # Upload Test Results
+  - ps: $wc = New-Object 'System.Net.WebClient'
+  - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\nosetests.xml))


### PR DESCRIPTION
**AppVeyor CI Workflow for NadaMq (and other packages with C dependencies)**

This pull request is mostly to be an example of how to handle CI workflows for python packages with C dependencies. There were a few decisions made during the process that I will highlight below:

1. ##### Why Use Mingw instead of MSVC? #####

    One of nadamq's dependencies (pycrc) produces c files incompatible with c99 and uses headers (such as stdint, and stdbool) that are not included in VS2008 (the default compiler for python27)

2. ##### Why is Mingw (and not just Mingw-runtime a run dependency)? #####

    The runtime and mingw depenencies both use the same dll file names. Also when in test phase, Conda for some reason doesn't look for libs in the DLL\ folder and only the Scripts\ folder. We don't want to include the Mingw-runtime dll's in the Scripts\ folder since this is where Mingw also places its dlls (and thus we won't be able to distinguish between dlls between the two packages) 
    
    #### This does however add significant overhead (since the entire mingw compiler is a runtime dependency) ####

